### PR TITLE
Wrong definition: Change Classification description to discrete

### DIFF
--- a/notebooks/LinearRegression.ipynb
+++ b/notebooks/LinearRegression.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "* Supervised: Target outputs are known and can be used for training (labelled data)\n",
     "  * Regression: Continuous target outputs\n",
-    "  * Classification: Continuous target outputs\n",
+    "  * Classification: Discrete target outputs\n",
     "  \n",
     "  Examples: Time-series prediction, face recognition\n",
     "\n",


### PR DESCRIPTION
Regression and classification both were described as continuous target outputs instead of continuous for regression and discrete for classification